### PR TITLE
Corrected Windows code and spelling

### DIFF
--- a/package-dev-modules/slides/02-setting-up-system/setting-up-system.Rmd
+++ b/package-dev-modules/slides/02-setting-up-system/setting-up-system.Rmd
@@ -404,14 +404,14 @@ Check if Git is already installed. Run the following in the *Terminal*.
 .pull-left[
 - Check if Git is installed
 
-```{bash}
+```{bash, eval = FALSE}
 which git
 ```
 ]
 .pull-right[
 - Check the version of your Git
 
-```{bash}
+```{bash, eval = FALSE}
 git --version
 ```
 ]
@@ -426,7 +426,7 @@ Add speaker notes
 
 ---
 
-## Instal Git
+## Install Git
 
 .your-turn[
 If `which git` didn't find Git installed, and if you weren't prompted to install it, run the following in the *Terminal*.
@@ -665,14 +665,14 @@ Check if Git is already installed. Run the following in the *Terminal*.
 .pull-left[
 - Check if Git is installed
 
-```{bash}
-which git
+```{bash, eval = FALSE}
+where git
 ```
 ]
 .pull-right[
 - Check the version of your Git
 
-```{bash}
+```{bash, eval = FALSE}
 git --version
 ```
 ]

--- a/package-dev-modules/slides/02-setting-up-system/setting-up-system.html
+++ b/package-dev-modules/slides/02-setting-up-system/setting-up-system.html
@@ -329,10 +329,6 @@ Check if Git is already installed. Run the following in the *Terminal*.
 ```bash
 which git
 ```
-
-```
-## /usr/bin/git
-```
 ]
 .pull-right[
 - Check the version of your Git
@@ -340,10 +336,6 @@ which git
 
 ```bash
 git --version
-```
-
-```
-## git version 2.24.3 (Apple Git-128)
 ```
 ]
 
@@ -357,7 +349,7 @@ Add speaker notes
 
 ---
 
-## Instal Git
+## Install Git
 
 .your-turn[
 If `which git` didn't find Git installed, and if you weren't prompted to install it, run the following in the *Terminal*.
@@ -613,11 +605,7 @@ Check if Git is already installed. Run the following in the *Terminal*.
 
 
 ```bash
-which git
-```
-
-```
-## /usr/bin/git
+where git
 ```
 ]
 .pull-right[
@@ -626,10 +614,6 @@ which git
 
 ```bash
 git --version
-```
-
-```
-## git version 2.24.3 (Apple Git-128)
 ```
 ]
 

--- a/package-dev-modules/slides/02-setting-up-system/style-xaringanthemer.css
+++ b/package-dev-modules/slides/02-setting-up-system/style-xaringanthemer.css
@@ -15,7 +15,7 @@
  *    - xaringan wiki: https://github.com/yihui/xaringan/wiki
  *    - remarkjs wiki: https://github.com/gnab/remark/wiki
  *
- *  Version: 0.4.0
+ *  Version: 0.4.1
  *
  * ------------------------------------------------------- */
 @import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap);
@@ -212,6 +212,36 @@ table.dataTable.hover tbody tr:hover, table.dataTable.display tbody tr:hover {
 }
 .dataTables_wrapper .dataTables_paginate .paginate_button {
   color: var(--text-color) !important;
+}
+
+/* Horizontal alignment of code blocks */
+.remark-slide-content.left pre,
+.remark-slide-content.center pre,
+.remark-slide-content.right pre {
+  text-align: start;
+  width: max-content;
+  max-width: 100%;
+}
+.remark-slide-content.left pre,
+.remark-slide-content.right pre {
+  min-width: 50%;
+  min-width: min(40ch, 100%);
+}
+.remark-slide-content.center pre {
+  min-width: 66%;
+  min-width: min(50ch, 100%);
+}
+.remark-slide-content.left pre {
+  margin-left: unset;
+  margin-right: auto;
+}
+.remark-slide-content.center pre {
+  margin-left: auto;
+  margin-right: auto;
+}
+.remark-slide-content.right pre {
+  margin-left: auto;
+  margin-right: unset;
 }
 
 /* Slide Header Background for h1 elements */


### PR DESCRIPTION
I made the change to the slide and added a missing l from  - https://github.com/forwards/workshops/blob/6ea624ca7a3c66c5f25b243c093e6986bf7fd4de/package-dev-modules/slides/02-setting-up-system/setting-up-system.Rmd#L429

To knit the Rmd I had to change the bash chunks to `{bash, eval = FALSE}`, I'm not sure if that's something related to my own setup though.